### PR TITLE
Fix: Reduce inventory cache TTL to 30 minutes (INTG-7)

### DIFF
--- a/src/main/mule/inventory-sync.xml
+++ b/src/main/mule/inventory-sync.xml
@@ -104,6 +104,6 @@ output application/json
 
     <os:object-store name="Inventory_Cache" doc:name="Inventory Cache"
                      persistent="false" maxEntries="10000"
-                     entryTtl="4" entryTtlUnit="HOURS"/>
+                     entryTtl="30" entryTtlUnit="MINUTES"/>
 
 </mule>


### PR DESCRIPTION
## Summary
Reduces the inventory Object Store cache TTL from 4 hours to 30 minutes.

## Problem
Customers reported seeing stale inventory data. The 4-hour cache TTL meant stock levels could be significantly outdated.

## Changes
- `inventory-sync.xml`: Changed `entryTtl` from 4 HOURS to 30 MINUTES

## Testing
- [x] Verified cache expiry in local environment
- [x] Confirmed NetSuite API handles increased call volume
- [ ] Deploy to Sandbox for integration testing

## Related
- GitHub Issue: #2
- JIRA: INTG-7